### PR TITLE
nvme support (wip)

### DIFF
--- a/usr/sbin/truenas-install
+++ b/usr/sbin/truenas-install
@@ -135,8 +135,14 @@ get_raid_present()
 get_physical_disks_list()
 {
     local _disk
+    local _nvmedisk
 
-    for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* /dev/nvme* 2>/dev/null | grep -v '[0-9]' | sed 's|/dev/||g')
+    for _nvmedisk in $(ls /dev/nvme* | grep -oP '(?<=/dev/nvme).*(?=p)' | sort -t: -u | sed 's/^/nvme/')
+    do
+	VAL="${VAL} ${_nvmedisk}"
+    done
+    
+    for _disk in $(ls /dev/sd* /dev/vd* /dev/hd* /dev/xvd* 2>/dev/null | grep -v '[0-9]' | sed 's|/dev/||g')
     do
 	VAL="${VAL} ${_disk}"
     done
@@ -282,8 +288,8 @@ install_loader()
 	    chroot ${_mnt} grub-install --target=i386-pc /dev/${_disk}
 
 	    echo "Stamping EFI loader on: ${_disk}"
-	    chroot ${_mnt} mkdosfs -F 32 -s 1 -n EFI /dev/${_disk}2
-	    chroot ${_mnt} mount -t vfat /dev/${_disk}2 /boot/efi
+	    chroot ${_mnt} mkdosfs -F 32 -s 1 -n EFI /dev/${_disk}p2
+	    chroot ${_mnt} mount -t vfat /dev/${_disk}p2 /boot/efi
 	    chroot ${_mnt} grub-install --target=x86_64-efi \
 		    --efi-directory=/boot/efi \
 		    --bootloader-id=debian --recheck --no-floppy
@@ -404,7 +410,7 @@ partition_disks()
 
     _disksparts=$(for _disk in ${_disks}; do
 	create_partitions ${_disk} >&2
-	echo /dev/${_disk}3
+	echo /dev/${_disk}p3
     done)
 
     if [ $# -gt 1 ]; then


### PR DESCRIPTION
This is the logic I'm currently using to try and install to an nvme disk. Unfortunately still not working correctly. I made some hardcoded changes for loading the EFI bootloader adding the letter p but for some odd reason, it isn't reflecting this. During post-install tasks, it errors out installing the bootloader to /dev/nvme0n12 when it should be /dev/nvme0n1p2, I don't know why the letter p isn't being added on.